### PR TITLE
Improve error callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ You can listen for the following events:
 
 - `qrCodeGenerated`: The QR Code is successfully generated
 - `qrCodeRegeneratedWithLogo`: The QR Code is successfully regenerated with the logo
-- `qrCodeGenerationFailed`: The QR Code generation failed. Check the console for more information
+- `qrCodeGenerationFailed`: The QR Code generation failed. Check the console for more information. The underlying exception can be retrieved via `e.detail`.
 
 ```svelte
 <QRCode

--- a/src/lib/qrcode/qrcode.svelte
+++ b/src/lib/qrcode/qrcode.svelte
@@ -110,6 +110,7 @@
 	// If the logo is not defined, the QR code will be visible immediately
 	// Otherwise, it will be visible after the logo has been loaded if `waitForLogo` is set to true or if the logo is already in base64 with `logoInBase64`
 	let qrCodeIsVisible: boolean = Boolean(logoInBase64) || !waitForLogo;
+	let qrCodeGenerationError: unknown = null;
 
 	const getQrCodeSvg = (regenerationWithLogo = false): string => {
 		try {
@@ -126,9 +127,8 @@
 			return QR_CODE.svg();
 		} catch (error) {
 			console.error('getQrCodeSvg: Failed to generate the QR code:', error);
-
-			dispatch('qrCodeGenerationFailed');
-
+			// We need to store the error instead of dispatching it right away because event dispatching does not work before the component is mounted.
+			qrCodeGenerationError = error;
 			return '';
 		}
 	};
@@ -226,6 +226,10 @@
 			OPTIONS.logoInBase64 = await convertLogoToBase64(logoPath);
 
 			qrCode = getQrCodeSvg(true);
+		}
+
+		if (qrCodeGenerationError) {
+			dispatch('qrCodeGenerationFailed');
 		}
 
 		qrCodeIsVisible = true;

--- a/src/lib/qrcode/qrcode.svelte
+++ b/src/lib/qrcode/qrcode.svelte
@@ -229,7 +229,7 @@
 		}
 
 		if (qrCodeGenerationError) {
-			dispatch('qrCodeGenerationFailed');
+			dispatch('qrCodeGenerationFailed', qrCodeGenerationError);
 		}
 
 		qrCodeIsVisible = true;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { QRCode } from '$lib/index';
+	import ErrorTest from './error-test.svelte';
 
 	let downloadUrl = '';
 	let downloadUrlJoin = '';
@@ -397,3 +398,6 @@
 <div>
 	<QRCode data="otpauth://totp/ACME%20Co:john.doe@email.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA1&digits=6&period=30" />
 </div>
+
+<h2>Error event test</h2>
+<ErrorTest />

--- a/src/routes/error-test.svelte
+++ b/src/routes/error-test.svelte
@@ -3,8 +3,9 @@
 
   let error = "No error detected. If this message is not replaced, then errors are not reported";
 
-  function onQrCodeGenerationFailed() {
-    error = "OK. Got an error while attempting to generate the content.";
+  function onQrCodeGenerationFailed(e) {
+    console.log("Got ", e);
+    error = `OK. Got an error while attempting to generate the content: ${e.detail.message}`;
   }
 </script>
 

--- a/src/routes/error-test.svelte
+++ b/src/routes/error-test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { QRCode } from '$lib/index';
+
+  let error = "No error detected. If this message is not replaced, then errors are not reported";
+
+  function onQrCodeGenerationFailed() {
+    error = "OK. Got an error while attempting to generate the content.";
+  }
+</script>
+
+<QRCode
+  data={" ".repeat(10000)}
+  on:qrCodeGenerationFailed={onQrCodeGenerationFailed} />
+{error}


### PR DESCRIPTION
Hi there,

I was trying to use this component to generate a QR code based on user input. When the QR code is too large, there is an exception that is logged only in the console. Trying to hook into the `qrCodeGenerationFailed` event did not seem to work so I looked a bit into it.

I started by creating a simple test that I added in the demo page.

<img width="510" alt="image" src="https://github.com/Castlenine/svelte-qrcode/assets/21236836/dcd0d82e-e607-49bb-a2f3-de434c45f16c">

I researched a bit and the problem appears to be that we are generating the QR code without logo in the component initialization phase, and apparently dispatching events from this state is not possible (see https://github.com/sveltejs/svelte/issues/4470 and https://github.com/sveltejs/svelte/issues/6106).

Two possible solutions: move QR code generation in `onMount` (just like the version with logo), or store the error and dispatch it later. In order to not affect too much the code base, I chose the second option.

In addition, I've passed the error as an argument to the event, so that the error can potentially be parsed or displayed to the user programatically.