### PR TITLE
Made logos adjust size to fit modules + made logo padding use modules as units

### DIFF
--- a/src/lib/qrcode/generate.ts
+++ b/src/lib/qrcode/generate.ts
@@ -1355,7 +1355,7 @@ class QRCode {
 
 			// Get the relative logo size
 			const LOGO_REL_WIDTH = (QR_CODE_WIDTH_SIZE * (this.options.logoWidth || 0)) / 100;
-			const LOGO_REL_HEIGHT = (QR_CODE_WIDTH_SIZE * (this.options.logoWidth || 0)) / 100;
+			const LOGO_REL_HEIGHT = (QR_CODE_HEIGHT_SIZE * (this.options.logoHeight || 0)) / 100;
 
 			// Adjust logo to fit modules
 			const LOGO_CEIL_W = Math.ceil(LOGO_REL_WIDTH / MODULE_SIZE);

--- a/src/lib/qrcode/generate.ts
+++ b/src/lib/qrcode/generate.ts
@@ -45,6 +45,12 @@
  *
  * - Added haveGappedModules
  *
+ * @version 2.3.0 (2024-09-27)
+ * @editor x032205
+ *
+ * - Made logos adjust size to fit modules
+ * - Made logo padding use modules as units
+ *
  */
 
 //---------------------------------------------------------------------
@@ -1343,20 +1349,34 @@ class QRCode {
 			const QR_CODE_WIDTH_SIZE = this.options.width;
 			const QR_CODE_HEIGHT_SIZE = this.options.height;
 
-			const LOGO_WIDTH = (QR_CODE_WIDTH_SIZE * (this.options.logoWidth || 15)) / 100;
-			const LOGO_HEIGHT = (QR_CODE_HEIGHT_SIZE * (this.options.logoHeight || 15)) / 100;
-			const LOGO_PADDING = this.options.logoPadding || 5;
+			// Get the size of each module
+			const MODULE_COUNT = this.qrCodeModel.getModuleCount();
+			const MODULE_SIZE = QR_CODE_WIDTH_SIZE / (MODULE_COUNT + 2 * this.options.padding);
+
+			// Get the relative logo size
+			const LOGO_REL_WIDTH = (QR_CODE_WIDTH_SIZE * (this.options.logoWidth || 0)) / 100;
+			const LOGO_REL_HEIGHT = (QR_CODE_WIDTH_SIZE * (this.options.logoWidth || 0)) / 100;
+
+			// Adjust logo to fit modules
+			const LOGO_CEIL_W = Math.ceil(LOGO_REL_WIDTH / MODULE_SIZE);
+			const LOGO_CEIL_H = Math.ceil(LOGO_REL_HEIGHT / MODULE_SIZE);
+			const ADJUSTED_LOGO_CEIL_W = LOGO_CEIL_W + (MODULE_COUNT % 2 === LOGO_CEIL_W % 2 ? 0 : 1);
+			const ADJUSTED_LOGO_CEIL_H = LOGO_CEIL_H + (MODULE_COUNT % 2 === LOGO_CEIL_H % 2 ? 0 : 1);
+			const LOGO_WIDTH = ADJUSTED_LOGO_CEIL_W * MODULE_SIZE;
+			const LOGO_HEIGHT = ADJUSTED_LOGO_CEIL_H * MODULE_SIZE;
+
+			const LOGO_PADDING = (this.options.logoPadding || 0) * MODULE_SIZE;
 			const LOGO_BACKGROUND_COLOR = this.options.logoBackgroundColor || this.options.backgroundColor;
 
 			const LOGO_X = QR_CODE_WIDTH_SIZE / 2 - LOGO_WIDTH / 2;
-			const LOGO_Y = QR_CODE_HEIGHT_SIZE / 2 - LOGO_WIDTH / 2; // Center the logo
+			const LOGO_Y = QR_CODE_HEIGHT_SIZE / 2 - LOGO_HEIGHT / 2; // Center the logo
 			const LOGO_BACKGROUND_X = QR_CODE_WIDTH_SIZE / 2 - LOGO_WIDTH / 2 - LOGO_PADDING;
 			const LOGO_BACKGROUND_Y = QR_CODE_HEIGHT_SIZE / 2 - LOGO_HEIGHT / 2 - LOGO_PADDING;
 			const LOGO_BACKGROUND_WIDTH = LOGO_WIDTH + LOGO_PADDING * 2;
 			const LOGO_BACKGROUND_HEIGHT = LOGO_HEIGHT + LOGO_PADDING * 2;
 
 			const LOGO_BACKGROUND_RECT = `<rect x="${LOGO_BACKGROUND_X}" y="${LOGO_BACKGROUND_Y}" width="${LOGO_BACKGROUND_WIDTH}" height="${LOGO_BACKGROUND_HEIGHT}" fill="${LOGO_BACKGROUND_COLOR}" style="shape-rendering:crispEdges;"/>`;
-			const LOGO = `<image href="${this.options.logoInBase64}" x="${LOGO_X}" y="${LOGO_Y}" width="${LOGO_WIDTH}" height="${LOGO_WIDTH}" preserveAspectRatio="xMidYMid meet"/>`;
+			const LOGO = `<image href="${this.options.logoInBase64}" x="${LOGO_X}" y="${LOGO_Y}" width="${LOGO_WIDTH}" height="${LOGO_HEIGHT}" preserveAspectRatio="xMidYMid meet"/>`;
 
 			const CLOSING_TAG_POS = svg.lastIndexOf('</svg>');
 

--- a/src/lib/qrcode/qrcode.svelte
+++ b/src/lib/qrcode/qrcode.svelte
@@ -73,7 +73,7 @@
 	export let logoInBase64 = ''; // base64-encoded logo image. If it's an empty string (`''`) or undefined, it will be ignored. Use this property instead of `logoPath` for faster logo loading times
 	export let logoPath = ''; // If it's an empty string (`''`), no logo will be added. Otherwise, the logo will be centered on the QR code. Typically, the logo file is located in the static folder
 	export let logoBackgroundColor = ''; // Color the logo background. If it's an empty string (`''`), the background color for the logo will be the same as the QR code `backgroundColor` property
-	export let logoPadding = 5; // Padding around the logo
+	export let logoPadding = 1; // Padding around the logo
 	export let logoSize = 15; // Size of the logo in percentage relative to the QR code size
 	export let logoWidth = logoSize; // Width of the logo in percentage relative to the QR code width
 	export let logoHeight = logoSize; // Height of the logo in percentage relative to the QR code height

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -204,7 +204,7 @@
 <p>Logo width & height</p>
 <div>
 	<!-- You can set a different logoWidth and LogoHeight  -->
-	<QRCode data="https://duxreserve.com" logoPath="/logo/lightning.svg" logoBackgroundColor="#009900" logoWidth={10} logoHeight={50} />
+	<QRCode data="https://duxreserve.com" logoPath="/logo/lightning.svg" logoBackgroundColor="#009900" logoWidth={20} logoHeight={30} />
 
 	<QRCode data="https://duxreserve.com" logoPath="/logo/lightning.svg" logoBackgroundColor="#009900" width={256} height={200} logoWidth={20} logoHeight={30} />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -204,7 +204,7 @@
 <p>Logo width & height</p>
 <div>
 	<!-- You can set a different logoWidth and LogoHeight  -->
-	<QRCode data="https://duxreserve.com" logoPath="/logo/lightning.svg" logoBackgroundColor="#009900" logoWidth={20} logoHeight={30} />
+	<QRCode data="https://duxreserve.com" logoPath="/logo/lightning.svg" logoBackgroundColor="#009900" logoWidth={10} logoHeight={50} />
 
 	<QRCode data="https://duxreserve.com" logoPath="/logo/lightning.svg" logoBackgroundColor="#009900" width={256} height={200} logoWidth={20} logoHeight={30} />
 </div>


### PR DESCRIPTION
This change makes logo sizes "adjust" to fit modules. The logo sizes still use "% of QR code" as the scaling unit, but they slightly adjust to prevent cut-off modules.

The second change was to make logoPadding use modules as units. So now a padding of 1 will be equivalent to removing one circle of units around the logo.

These changes were made to solve this issue: https://github.com/Castlenine/svelte-qrcode/issues/3

## Before

<img width="412" alt="image" src="https://github.com/user-attachments/assets/cd82a763-0b11-47b3-9905-f3eba104ee92">

<img width="204" alt="image" src="https://github.com/user-attachments/assets/318c2fa7-616a-4c8e-bd15-2b89a1d918ce">

<img width="416" alt="image" src="https://github.com/user-attachments/assets/3a6a2b51-b78a-4f72-9ae1-20966a84a11a">

## After

<img width="414" alt="image" src="https://github.com/user-attachments/assets/e0a03ad8-5489-495a-80e7-df3a31bc4473">

<img width="204" alt="image" src="https://github.com/user-attachments/assets/9e016bb6-5e58-4fb5-9d5f-a6dae63578e3">

<img width="408" alt="image" src="https://github.com/user-attachments/assets/969ff9e9-5643-4b33-b263-8b361e5a0c04">
